### PR TITLE
feat: add jsonpath-yaml parser for yaml artifacts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/marcboeker/go-duckdb v1.8.5
 	github.com/spf13/cobra v1.9.1
 	golang.org/x/text v0.22.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -26,6 +27,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,10 @@ github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IX
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=
 github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/marcboeker/go-duckdb v1.8.5 h1:tkYp+TANippy0DaIOP5OEfBEwbUINqiFqgwMQ44jME0=
 github.com/marcboeker/go-duckdb v1.8.5/go.mod h1:6mK7+WQE4P4u5AFLvVBmhFxY5fvhymFptghgJX6B+/8=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
@@ -49,6 +53,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
@@ -77,5 +83,7 @@ golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da/go.mod h1:NDW/Ps6MPRej6f
 gonum.org/v1/gonum v0.15.1 h1:FNy7N6OUZVUaWG9pTiD+jlhdQ3lMP+/LcTpJ6+a8sQ0=
 gonum.org/v1/gonum v0.15.1/go.mod h1:eZTZuRFrzu5pcyjN5wJhcIhnUdNijYxX1T2IcrOGY0o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/parser/jsonpath.go
+++ b/internal/parser/jsonpath.go
@@ -42,6 +42,10 @@ func (e *JSONPathExtractor) Extract(artifact *falba.Artifact) ([]falba.Value, er
 		return nil, fmt.Errorf("failed to evaluate JSONPath: %v", err)
 	}
 
+	return evalJSONPathResult(got, e.resultType, "JSONPath")
+}
+
+func evalJSONPathResult(got any, resultType falba.ValueType, name string) ([]falba.Value, error) {
 	var rawValues []any
 	switch got := got.(type) {
 	case []any:
@@ -53,7 +57,7 @@ func (e *JSONPathExtractor) Extract(artifact *falba.Artifact) ([]falba.Value, er
 	var result []falba.Value
 	for _, rawVal := range rawValues {
 		var val falba.Value
-		switch e.resultType {
+		switch resultType {
 		case falba.ValueInt:
 			// JSON doesn't have proper numeric types so we can't actually enforce
 			// that the value is an integer. Just squash it into one.
@@ -63,24 +67,24 @@ func (e *JSONPathExtractor) Extract(artifact *falba.Artifact) ([]falba.Value, er
 			case int:
 				val = &falba.IntValue{Value: int64(v)}
 			default:
-				return nil, fmt.Errorf("%w: JSONPath returned %T, wanted numeric", ErrParseFailure, rawVal)
+				return nil, fmt.Errorf("%w: %s returned %T, wanted numeric", ErrParseFailure, name, rawVal)
 			}
 		case falba.ValueString:
 			v, ok := rawVal.(string)
 			if !ok {
-				return nil, fmt.Errorf("%w: JSONPath returned %T, wanted string", ErrParseFailure, rawVal)
+				return nil, fmt.Errorf("%w: %s returned %T, wanted string", ErrParseFailure, name, rawVal)
 			}
 			val = &falba.StringValue{Value: v}
 		case falba.ValueFloat:
 			v, ok := rawVal.(float64)
 			if !ok {
-				return nil, fmt.Errorf("%w: JSONPath returned %T, wanted float64", ErrParseFailure, rawVal)
+				return nil, fmt.Errorf("%w: %s returned %T, wanted float64", ErrParseFailure, name, rawVal)
 			}
 			val = &falba.FloatValue{Value: v}
 		case falba.ValueBool:
 			v, ok := rawVal.(bool)
 			if !ok {
-				return nil, fmt.Errorf("%w: JSONPath returned %T, wanted bool", ErrParseFailure, rawVal)
+				return nil, fmt.Errorf("%w: %s returned %T, wanted bool", ErrParseFailure, name, rawVal)
 			}
 			val = &falba.BoolValue{Value: v}
 		default:

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -307,7 +307,7 @@ func FromConfig(rawConfig json.RawMessage, name string) (*Parser, error) {
 		decoder.DisallowUnknownFields()
 		var config JSONPPathConfig
 		if err := decoder.Decode(&config); err != nil {
-			return nil, fmt.Errorf("decoding single_metric parser config: %v", err)
+			return nil, fmt.Errorf("decoding jsonpath parser config: %v", err)
 		}
 		if err := config.ValidateFields(); err != nil {
 			return nil, fmt.Errorf("invalid %q parser config: %v", baseConfig.Type, err)
@@ -316,6 +316,21 @@ func FromConfig(rawConfig json.RawMessage, name string) (*Parser, error) {
 		extractor, err = NewJSONPathExtractor(config.JSONPath, target.ValueType)
 		if err != nil {
 			return nil, fmt.Errorf("setting up JSONPath extractor: %v", err)
+		}
+	case "jsonpath-yaml":
+		decoder := json.NewDecoder(strings.NewReader(string(rawConfig)))
+		decoder.DisallowUnknownFields()
+		var config YAMLPathConfig
+		if err := decoder.Decode(&config); err != nil {
+			return nil, fmt.Errorf("decoding jsonpath-yaml parser config: %v", err)
+		}
+		if err := config.ValidateFields(); err != nil {
+			return nil, fmt.Errorf("invalid %q parser config: %v", baseConfig.Type, err)
+		}
+		var err error
+		extractor, err = NewYAMLPathExtractor(config.JSONPath, target.ValueType)
+		if err != nil {
+			return nil, fmt.Errorf("setting up YAMLPath extractor: %v", err)
 		}
 	case "shellvar":
 		decoder := json.NewDecoder(strings.NewReader(string(rawConfig)))

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -748,6 +748,41 @@ func TestJSONPathParser(t *testing.T) {
 			t.Errorf("Expected error about missing 'jsonpath' field, got: %v", err)
 		}
 	})
+
+	t.Run("FromConfig jsonpath-yaml", func(t *testing.T) {
+		configJSON := `{
+			"type": "jsonpath-yaml",
+			"artifact_regexp": "\\.yaml$",
+			"jsonpath": "$.name",
+			"fact": {
+				"name": "entity_name",
+				"type": "string"
+			}
+		}`
+		p, err := parser.FromConfig([]byte(configJSON), "jsonpath_yaml_test_parser")
+		if err != nil {
+			t.Fatalf("FromConfig failed: %v", err)
+		}
+		if p.Name != "jsonpath_yaml_test_parser" || p.ArtifactRE.String() != "\\.yaml$" || p.Target.Name != "entity_name" {
+			t.Errorf("Parser fields mismatch")
+		}
+		_, ok := p.Extractor.(*parser.YAMLPathExtractor)
+		if !ok {
+			t.Fatalf("Extractor is not of type *YAMLPathExtractor, got %T", p.Extractor)
+		}
+	})
+
+	t.Run("FromConfig jsonpath-yaml missing jsonpath field", func(t *testing.T) {
+		configJSON := `{
+			"type": "jsonpath-yaml",
+			"artifact_regexp": "\\.yaml$",
+			"metric": { "name": "foo", "type": "string" }
+		}`
+		_, err := parser.FromConfig([]byte(configJSON), "test")
+		if err == nil || !strings.Contains(err.Error(), "missing/empty 'jsonpath' field") {
+			t.Errorf("Expected error about missing 'jsonpath' field, got: %v", err)
+		}
+	})
 }
 
 func TestReservedFactNamesRejected(t *testing.T) {

--- a/internal/parser/yamlpath.go
+++ b/internal/parser/yamlpath.go
@@ -30,58 +30,12 @@ func (e *YAMLPathExtractor) Extract(artifact *falba.Artifact) ([]falba.Value, er
 		return nil, fmt.Errorf("%w: unmarshalling from YAML: %v", ErrParseFailure, err)
 	}
 
-	// yaml.v3 creates map[string]interface{} by default when decoding into any,
-	// which is perfectly compatible with jsonpath.
 	got, err := jsonpath.Get(e.expression, obj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to evaluate JSONPath on YAML: %v", err)
 	}
 
-	var rawValues []any
-	switch got := got.(type) {
-	case []any:
-		rawValues = got
-	default:
-		rawValues = []any{got}
-	}
-
-	var result []falba.Value
-	for _, rawVal := range rawValues {
-		var val falba.Value
-		switch e.resultType {
-		case falba.ValueInt:
-			switch v := rawVal.(type) {
-			case float64:
-				val = &falba.IntValue{Value: int64(v)}
-			case int:
-				val = &falba.IntValue{Value: int64(v)}
-			default:
-				return nil, fmt.Errorf("%w: YAMLPath returned %T, wanted numeric", ErrParseFailure, rawVal)
-			}
-		case falba.ValueString:
-			v, ok := rawVal.(string)
-			if !ok {
-				return nil, fmt.Errorf("%w: YAMLPath returned %T, wanted string", ErrParseFailure, rawVal)
-			}
-			val = &falba.StringValue{Value: v}
-		case falba.ValueFloat:
-			v, ok := rawVal.(float64)
-			if !ok {
-				return nil, fmt.Errorf("%w: YAMLPath returned %T, wanted float64", ErrParseFailure, rawVal)
-			}
-			val = &falba.FloatValue{Value: v}
-		case falba.ValueBool:
-			v, ok := rawVal.(bool)
-			if !ok {
-				return nil, fmt.Errorf("%w: YAMLPath returned %T, wanted bool", ErrParseFailure, rawVal)
-			}
-			val = &falba.BoolValue{Value: v}
-		default:
-			panic("unimplemented")
-		}
-		result = append(result, val)
-	}
-	return result, nil
+	return evalJSONPathResult(got, e.resultType, "YAMLPath")
 }
 
 func (p *YAMLPathExtractor) String() string {

--- a/internal/parser/yamlpath.go
+++ b/internal/parser/yamlpath.go
@@ -1,0 +1,104 @@
+package parser
+
+import (
+	"fmt"
+
+	"github.com/PaesslerAG/jsonpath"
+	"github.com/bjackman/falba/internal/falba"
+	"gopkg.in/yaml.v3"
+)
+
+type YAMLPathExtractor struct {
+	resultType falba.ValueType
+	expression string
+}
+
+func NewYAMLPathExtractor(expr string, resultType falba.ValueType) (*YAMLPathExtractor, error) {
+	return &YAMLPathExtractor{
+		expression: expr,
+		resultType: resultType,
+	}, nil
+}
+
+func (e *YAMLPathExtractor) Extract(artifact *falba.Artifact) ([]falba.Value, error) {
+	content, err := artifact.Content()
+	if err != nil {
+		return nil, fmt.Errorf("getting artifact content: %v", err)
+	}
+	var obj any
+	if err := yaml.Unmarshal(content, &obj); err != nil {
+		return nil, fmt.Errorf("%w: unmarshalling from YAML: %v", ErrParseFailure, err)
+	}
+
+	// yaml.v3 creates map[string]interface{} by default when decoding into any,
+	// which is perfectly compatible with jsonpath.
+	got, err := jsonpath.Get(e.expression, obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate JSONPath on YAML: %v", err)
+	}
+
+	var rawValues []any
+	switch got := got.(type) {
+	case []any:
+		rawValues = got
+	default:
+		rawValues = []any{got}
+	}
+
+	var result []falba.Value
+	for _, rawVal := range rawValues {
+		var val falba.Value
+		switch e.resultType {
+		case falba.ValueInt:
+			switch v := rawVal.(type) {
+			case float64:
+				val = &falba.IntValue{Value: int64(v)}
+			case int:
+				val = &falba.IntValue{Value: int64(v)}
+			default:
+				return nil, fmt.Errorf("%w: YAMLPath returned %T, wanted numeric", ErrParseFailure, rawVal)
+			}
+		case falba.ValueString:
+			v, ok := rawVal.(string)
+			if !ok {
+				return nil, fmt.Errorf("%w: YAMLPath returned %T, wanted string", ErrParseFailure, rawVal)
+			}
+			val = &falba.StringValue{Value: v}
+		case falba.ValueFloat:
+			v, ok := rawVal.(float64)
+			if !ok {
+				return nil, fmt.Errorf("%w: YAMLPath returned %T, wanted float64", ErrParseFailure, rawVal)
+			}
+			val = &falba.FloatValue{Value: v}
+		case falba.ValueBool:
+			v, ok := rawVal.(bool)
+			if !ok {
+				return nil, fmt.Errorf("%w: YAMLPath returned %T, wanted bool", ErrParseFailure, rawVal)
+			}
+			val = &falba.BoolValue{Value: v}
+		default:
+			panic("unimplemented")
+		}
+		result = append(result, val)
+	}
+	return result, nil
+}
+
+func (p *YAMLPathExtractor) String() string {
+	return fmt.Sprintf("YAMLPathParser{%q -> %v}", p.expression, p.resultType)
+}
+
+type YAMLPathConfig struct {
+	BaseParserConfig
+	JSONPath string `json:"jsonpath"`
+}
+
+func (c *YAMLPathConfig) ValidateFields() error {
+	if err := c.BaseParserConfig.ValidateFields(); err != nil {
+		return err
+	}
+	if c.JSONPath == "" {
+		return fmt.Errorf("missing/empty 'jsonpath' field")
+	}
+	return nil
+}

--- a/internal/parser/yamlpath_test.go
+++ b/internal/parser/yamlpath_test.go
@@ -1,0 +1,153 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bjackman/falba/internal/falba"
+	"github.com/google/go-cmp/cmp"
+)
+
+func fakeYamlArtifact(t *testing.T, content string) *falba.Artifact {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "artifact.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write artifact: %v", err)
+	}
+	return &falba.Artifact{Name: "artifact.yaml", Path: path}
+}
+
+func TestYAMLPathExtractor(t *testing.T) {
+	cases := []struct {
+		name       string
+		expression string
+		yaml       string
+		valType    falba.ValueType
+		want       []falba.Value
+		wantErr    bool
+	}{
+		{
+			name:       "simple string",
+			expression: "$.foo",
+			yaml:       "foo: bar",
+			valType:    falba.ValueString,
+			want:       []falba.Value{&falba.StringValue{Value: "bar"}},
+		},
+		{
+			name:       "simple int",
+			expression: "$.foo",
+			yaml:       "foo: 42",
+			valType:    falba.ValueInt,
+			want:       []falba.Value{&falba.IntValue{Value: 42}},
+		},
+		{
+			name:       "simple float",
+			expression: "$.foo",
+			yaml:       "foo: 42.5",
+			valType:    falba.ValueFloat,
+			want:       []falba.Value{&falba.FloatValue{Value: 42.5}},
+		},
+		{
+			name:       "simple bool",
+			expression: "$.foo",
+			yaml:       "foo: true",
+			valType:    falba.ValueBool,
+			want:       []falba.Value{&falba.BoolValue{Value: true}},
+		},
+		{
+			name:       "array extraction string",
+			expression: "$.foo[*]",
+			yaml:       "foo:\n  - a\n  - b",
+			valType:    falba.ValueString,
+			want:       []falba.Value{&falba.StringValue{Value: "a"}, &falba.StringValue{Value: "b"}},
+		},
+		{
+			name:       "array extraction int",
+			expression: "$.foo[*]",
+			yaml:       "foo:\n  - 1\n  - 2",
+			valType:    falba.ValueInt,
+			want:       []falba.Value{&falba.IntValue{Value: 1}, &falba.IntValue{Value: 2}},
+		},
+		{
+			name:       "nested object",
+			expression: "$.foo.bar.baz",
+			yaml:       "foo:\n  bar:\n    baz: hello",
+			valType:    falba.ValueString,
+			want:       []falba.Value{&falba.StringValue{Value: "hello"}},
+		},
+		{
+			name:       "wrong type float to string",
+			expression: "$.foo",
+			yaml:       "foo: 42.5",
+			valType:    falba.ValueString,
+			wantErr:    true,
+		},
+		{
+			name:       "wrong type string to int",
+			expression: "$.foo",
+			yaml:       "foo: bar",
+			valType:    falba.ValueInt,
+			wantErr:    true,
+		},
+		{
+			name:       "missing key",
+			expression: "$.bar",
+			yaml:       "foo: 42",
+			valType:    falba.ValueInt,
+			wantErr:    true,
+		},
+		{
+			name:       "invalid expression",
+			expression: "$.[",
+			yaml:       "foo: 42",
+			valType:    falba.ValueInt,
+			wantErr:    true, // Fails during Get
+		},
+		{
+			name:       "invalid yaml",
+			expression: "$.foo",
+			yaml:       "foo: [",
+			valType:    falba.ValueInt,
+			wantErr:    true, // Fails during Unmarshal
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			extractor, err := NewYAMLPathExtractor(tc.expression, tc.valType)
+			if err != nil {
+				t.Fatalf("Failed to create extractor: %v", err)
+			}
+
+			artifact := fakeYamlArtifact(t, tc.yaml)
+			got, err := extractor.Extract(artifact)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Extract() got no error, wanted error. Result was %v", got)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Extract() got unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Extract() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestYAMLPathExtractorString(t *testing.T) {
+	extractor, _ := NewYAMLPathExtractor("$.foo", falba.ValueString)
+	got := extractor.String()
+	want := fmt.Sprintf("YAMLPathParser{%q -> %v}", "$.foo", falba.ValueString)
+	if got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Adds a `jsonpath-yaml` parser to extract facts and metrics from YAML artifacts using JSONPath expressions. Evaluates YAML by unmarshalling to Go `any` types and running JSONPath queries over the result.

Features:
- Configures with `type: "jsonpath-yaml"` and a `jsonpath` expression string.
- Maps output queries accurately to string, int, float, and bool facts/metrics.
- Uses `gopkg.in/yaml.v3` for parsing YAML cleanly.
- Tests to handle invalid queries, malformed YAML, nested types, array extraction, and type mismatch errors.

---
*PR created automatically by Jules for task [3414535357432043182](https://jules.google.com/task/3414535357432043182) started by @bjackman*