### PR TITLE
feat: Add support for FALBA_PARSERS_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ A **Metric** is an output measured during the test. Unlike Facts, a Metric can h
 A Falba database is simply a directory on your filesystem. You can start with an empty directory.
 
 ### Configuring Parsers
-To tell Falba how to interpret your artifacts, create a `parsers.json` file in the root of your database directory. This file defines which files to look at and what data to extract.
+To tell Falba how to interpret your artifacts, you can provide configuration files that define which files to look at and what data to extract.
+
+By default, Falba looks for a `parsers.json` file in the root of your database directory. Alternatively, or in addition, you can set the `FALBA_PARSERS_PATH` environment variable. This should be a `:`-separated list of directories. Falba will load and merge all `.json` files found within these directories, as well as the database's own `parsers.json` (if it exists).
+
+If a parser with the same name is defined in multiple files, Falba will return an error.
 
 Example `parsers.json`:
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,14 @@ var (
 func setupSQL() (*db.DB, *sql.DB, error) {
 	parsersPaths := []string{}
 	if path := os.Getenv("FALBA_PARSERS_PATH"); path != "" {
-		parsersPaths = strings.Split(path, ":")
+		for _, p := range strings.Split(path, ":") {
+			if p == "" {
+				continue
+			}
+			if _, err := os.Stat(p); err == nil {
+				parsersPaths = append(parsersPaths, p)
+			}
+		}
 	}
 
 	falbaDB, err := db.ReadDB(flagResultDB, parsersPaths)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 
@@ -15,7 +16,7 @@ var (
 	duckDBPath   string = "falba.duckdb"
 )
 
-func setupSQL() (*db.DB, *sql.DB, error) {
+func getParsersPaths() []string {
 	parsersPaths := []string{}
 	if path := os.Getenv("FALBA_PARSERS_PATH"); path != "" {
 		for _, p := range strings.Split(path, ":") {
@@ -24,9 +25,16 @@ func setupSQL() (*db.DB, *sql.DB, error) {
 			}
 			if _, err := os.Stat(p); err == nil {
 				parsersPaths = append(parsersPaths, p)
+			} else if !os.IsNotExist(err) {
+				log.Printf("Warning: ignoring parsers path %q: %v", p, err)
 			}
 		}
 	}
+	return parsersPaths
+}
+
+func setupSQL() (*db.DB, *sql.DB, error) {
+	parsersPaths := getParsersPaths()
 
 	falbaDB, err := db.ReadDB(flagResultDB, parsersPaths)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/bjackman/falba/internal/db"
 	"github.com/spf13/cobra"
@@ -15,7 +16,12 @@ var (
 )
 
 func setupSQL() (*db.DB, *sql.DB, error) {
-	falbaDB, err := db.ReadDB(flagResultDB)
+	parsersPaths := []string{}
+	if path := os.Getenv("FALBA_PARSERS_PATH"); path != "" {
+		parsersPaths = strings.Split(path, ":")
+	}
+
+	falbaDB, err := db.ReadDB(flagResultDB, parsersPaths)
 	if err != nil {
 		return nil, nil, fmt.Errorf("opening Falba DB: %v", err)
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -198,26 +198,23 @@ func parseParserConfig(configPath string) (*ParsersConfig, error) {
 	return &config, nil
 }
 
-func loadParsers(rootDir string) ([]*parser.Parser, error) {
+func loadParsers(rootDir string, parsersPaths []string) ([]*parser.Parser, error) {
 	configPaths := []string{}
 
-	if parsersPath := os.Getenv("FALBA_PARSERS_PATH"); parsersPath != "" {
-		dirs := strings.Split(parsersPath, ":")
-		for _, dir := range dirs {
-			if dir == "" {
+	for _, dir := range parsersPaths {
+		if dir == "" {
+			continue
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
 				continue
 			}
-			entries, err := os.ReadDir(dir)
-			if err != nil {
-				if os.IsNotExist(err) {
-					continue
-				}
-				return nil, fmt.Errorf("reading directory from FALBA_PARSERS_PATH %v: %w", dir, err)
-			}
-			for _, entry := range entries {
-				if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
-					configPaths = append(configPaths, filepath.Join(dir, entry.Name()))
-				}
+			return nil, fmt.Errorf("reading directory from parsers path %v: %w", dir, err)
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
+				configPaths = append(configPaths, filepath.Join(dir, entry.Name()))
 			}
 		}
 	}
@@ -258,8 +255,8 @@ func loadParsers(rootDir string) ([]*parser.Parser, error) {
 
 // Read all the results from a DB directory and parse all their facts and
 // metrics.
-func ReadDB(rootDir string) (*DB, error) {
-	parsers, err := loadParsers(rootDir)
+func ReadDB(rootDir string, parsersPaths []string) (*DB, error) {
+	parsers, err := loadParsers(rootDir, parsersPaths)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -182,7 +182,7 @@ type ParsersConfig struct {
 	Parsers map[string]json.RawMessage `json:"parsers"`
 }
 
-func parseParserConfig(configPath string) ([]*parser.Parser, error) {
+func parseParserConfig(configPath string) (*ParsersConfig, error) {
 	configContent, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading DB config from %v: %w", configPath, err)
@@ -193,10 +193,57 @@ func parseParserConfig(configPath string) ([]*parser.Parser, error) {
 
 	var config ParsersConfig
 	if err := decoder.Decode(&config); err != nil {
-		return nil, fmt.Errorf("decoding DB config: %w", err)
+		return nil, fmt.Errorf("decoding DB config from %v: %w", configPath, err)
 	}
+	return &config, nil
+}
+
+func loadParsers(rootDir string) ([]*parser.Parser, error) {
+	configPaths := []string{}
+
+	if parsersPath := os.Getenv("FALBA_PARSERS_PATH"); parsersPath != "" {
+		dirs := strings.Split(parsersPath, ":")
+		for _, dir := range dirs {
+			if dir == "" {
+				continue
+			}
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				return nil, fmt.Errorf("reading directory from FALBA_PARSERS_PATH %v: %w", dir, err)
+			}
+			for _, entry := range entries {
+				if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
+					configPaths = append(configPaths, filepath.Join(dir, entry.Name()))
+				}
+			}
+		}
+	}
+
+	dbParsersPath := filepath.Join(rootDir, "parsers.json")
+	if _, err := os.Stat(dbParsersPath); err == nil {
+		configPaths = append(configPaths, dbParsersPath)
+	}
+
+	mergedParsers := make(map[string]json.RawMessage)
+
+	for _, configPath := range configPaths {
+		config, err := parseParserConfig(configPath)
+		if err != nil {
+			return nil, err
+		}
+		for name, parserConfig := range config.Parsers {
+			if _, exists := mergedParsers[name]; exists {
+				return nil, fmt.Errorf("duplicate parser name %q found in %v", name, configPath)
+			}
+			mergedParsers[name] = parserConfig
+		}
+	}
+
 	var parsers []*parser.Parser
-	for name, parserConfig := range config.Parsers {
+	for name, parserConfig := range mergedParsers {
 		parser, err := parser.FromConfig(parserConfig, name)
 		if err != nil {
 			return nil, fmt.Errorf("configuring parser %q: %w", name, err)
@@ -204,7 +251,7 @@ func parseParserConfig(configPath string) ([]*parser.Parser, error) {
 		parsers = append(parsers, parser)
 	}
 	if len(parsers) == 0 {
-		return nil, fmt.Errorf("no 'parsers' defined")
+		return nil, fmt.Errorf("no 'parsers' defined or could not find any parsers configuration")
 	}
 	return parsers, nil
 }
@@ -212,7 +259,7 @@ func parseParserConfig(configPath string) ([]*parser.Parser, error) {
 // Read all the results from a DB directory and parse all their facts and
 // metrics.
 func ReadDB(rootDir string) (*DB, error) {
-	parsers, err := parseParserConfig(filepath.Join(rootDir, "parsers.json"))
+	parsers, err := loadParsers(rootDir)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -202,14 +202,8 @@ func loadParsers(rootDir string, parsersPaths []string) ([]*parser.Parser, error
 	configPaths := []string{}
 
 	for _, dir := range parsersPaths {
-		if dir == "" {
-			continue
-		}
 		entries, err := os.ReadDir(dir)
 		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
 			return nil, fmt.Errorf("reading directory from parsers path %v: %w", dir, err)
 		}
 		for _, entry := range entries {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -27,7 +27,7 @@ func resultsMap(t *testing.T, results []*falba.Result) map[string]*falba.Result 
 }
 
 func TestReadDB(t *testing.T) {
-	db, err := db.ReadDB("testdata/results")
+	db, err := db.ReadDB("testdata/results", nil)
 	if err != nil {
 		t.Fatalf("Failed to read DB: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestReadDB_DuplicateFactInResult(t *testing.T) {
 		t.Fatalf("Failed to write file2.txt: %v", err)
 	}
 
-	_, err := db.ReadDB(tempDir)
+	_, err := db.ReadDB(tempDir, nil)
 	if err == nil {
 		t.Fatalf("Expected ReadDB to return an error for duplicate fact production, but got nil")
 	}
@@ -158,7 +158,7 @@ func TestReadDB_MissingArtifactsDir(t *testing.T) {
 	}
 	// No artifacts/ directory is created here
 
-	_, err := db.ReadDB(tempDir)
+	_, err := db.ReadDB(tempDir, nil)
 	if err == nil {
 		t.Fatalf("Expected ReadDB to return an error when artifacts/ dir is missing, but got nil")
 	}
@@ -179,7 +179,7 @@ func TestReadDB_UnknownFieldsInParsersFile(t *testing.T) {
 		t.Fatalf("Failed to write parsers.json: %v", err)
 	}
 
-	_, err := db.ReadDB(tempDir)
+	_, err := db.ReadDB(tempDir, nil)
 	if err == nil {
 		t.Fatalf("Expected ReadDB to return an error for unknown fields in parsers.json, but got nil")
 	}
@@ -196,7 +196,7 @@ func TestReadDB_InvalidJSONParsersFile(t *testing.T) {
 		t.Fatalf("Failed to write parsers.json: %v", err)
 	}
 
-	_, err := db.ReadDB(tempDir)
+	_, err := db.ReadDB(tempDir, nil)
 	if err == nil {
 		t.Fatalf("Expected ReadDB to return an error for invalid JSON, but got nil")
 	}
@@ -213,7 +213,7 @@ func TestReadDB_EmptyParsersMap(t *testing.T) {
 		t.Fatalf("Failed to write parsers.json: %v", err)
 	}
 
-	_, err := db.ReadDB(tempDir)
+	_, err := db.ReadDB(tempDir, nil)
 	if err == nil {
 		t.Fatalf("Expected ReadDB to return an error for empty parsers map, but got nil")
 	}
@@ -227,7 +227,7 @@ func TestReadDB_MissingParsersFile(t *testing.T) {
 	tempDir := t.TempDir()
 	// No parsers.json created
 
-	_, err := db.ReadDB(tempDir)
+	_, err := db.ReadDB(tempDir, nil)
 	if err == nil {
 		t.Fatalf("Expected ReadDB to return an error when parsers.json is missing, but got nil")
 	}
@@ -280,9 +280,7 @@ func TestReadDB_FALBAParsersPath(t *testing.T) {
 		t.Fatalf("Failed to write config2.json: %v", err)
 	}
 
-	// db root without parsers.json should be fine because FALBA_PARSERS_PATH contains valid ones
-	os.Setenv("FALBA_PARSERS_PATH", dir1+":"+dir2)
-	defer os.Unsetenv("FALBA_PARSERS_PATH")
+	// db root without parsers.json should be fine because parsers paths contains valid ones
 
 	// Create dummy result to avoid empty db
 	resultDir := filepath.Join(dbRoot, "test_result:123")
@@ -291,7 +289,7 @@ func TestReadDB_FALBAParsersPath(t *testing.T) {
 		t.Fatalf("Failed to create artifacts dir: %v", err)
 	}
 
-	dbInstance, err := db.ReadDB(dbRoot)
+	dbInstance, err := db.ReadDB(dbRoot, []string{dir1, dir2})
 	if err != nil {
 		t.Fatalf("Expected ReadDB to succeed, got error: %v", err)
 	}
@@ -347,10 +345,7 @@ func TestReadDB_FALBAParsersPath_Duplicate(t *testing.T) {
 		t.Fatalf("Failed to write db root parsers.json: %v", err)
 	}
 
-	os.Setenv("FALBA_PARSERS_PATH", dir1)
-	defer os.Unsetenv("FALBA_PARSERS_PATH")
-
-	_, err := db.ReadDB(dbRoot)
+	_, err := db.ReadDB(dbRoot, []string{dir1})
 	if err == nil {
 		t.Fatalf("Expected ReadDB to fail due to duplicate parser name, but got nil")
 	}
@@ -402,7 +397,7 @@ func TestReadDB_ConflictingTypes(t *testing.T) {
 		t.Fatalf("Failed to write dummy artifact raw_data.txt: %v", err)
 	}
 
-	_, err := db.ReadDB(tempDir)
+	_, err := db.ReadDB(tempDir, nil)
 	if err == nil {
 		t.Errorf("Expected ReadDB to return an error due to conflicting types, but got nil")
 	} else {
@@ -465,7 +460,7 @@ func TestReadDB_InvalidResultDirName(t *testing.T) {
 				t.Fatalf("Failed to create artifacts dir in %s: %v", resultDir, err)
 			}
 
-			_, err := db.ReadDB(tempDir)
+			_, err := db.ReadDB(tempDir, nil)
 			if err == nil {
 				t.Fatalf("Expected ReadDB to return an error for dir %s, but got nil", tc.dirName)
 			}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -231,8 +231,131 @@ func TestReadDB_MissingParsersFile(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected ReadDB to return an error when parsers.json is missing, but got nil")
 	}
-	if !strings.Contains(err.Error(), "reading DB config from") || !strings.Contains(err.Error(), "parsers.json") {
-		t.Errorf("Expected error to mention missing parsers.json, got: %v", err)
+	if !strings.Contains(err.Error(), "no 'parsers' defined or could not find any parsers configuration") {
+		t.Errorf("Expected error to mention no 'parsers' defined, got: %v", err)
+	}
+}
+
+// This test was written by Google Jules.
+func TestReadDB_FALBAParsersPath(t *testing.T) {
+	tempDir := t.TempDir()
+
+	dir1 := filepath.Join(tempDir, "parsers1")
+	dir2 := filepath.Join(tempDir, "parsers2")
+	dbRoot := filepath.Join(tempDir, "db_root")
+
+	if err := os.MkdirAll(dir1, 0755); err != nil {
+		t.Fatalf("Failed to create parsers1 dir: %v", err)
+	}
+	if err := os.MkdirAll(dir2, 0755); err != nil {
+		t.Fatalf("Failed to create parsers2 dir: %v", err)
+	}
+	if err := os.MkdirAll(dbRoot, 0755); err != nil {
+		t.Fatalf("Failed to create db root dir: %v", err)
+	}
+
+	parser1Content := `{
+		"parsers": {
+			"parser_1": {
+				"type": "single_metric",
+				"artifact_regexp": "file1\\.txt",
+				"fact": {"name": "fact1", "type": "string"}
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(dir1, "config1.json"), []byte(parser1Content), 0644); err != nil {
+		t.Fatalf("Failed to write config1.json: %v", err)
+	}
+
+	parser2Content := `{
+		"parsers": {
+			"parser_2": {
+				"type": "single_metric",
+				"artifact_regexp": "file2\\.txt",
+				"fact": {"name": "fact2", "type": "string"}
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(dir2, "config2.json"), []byte(parser2Content), 0644); err != nil {
+		t.Fatalf("Failed to write config2.json: %v", err)
+	}
+
+	// db root without parsers.json should be fine because FALBA_PARSERS_PATH contains valid ones
+	os.Setenv("FALBA_PARSERS_PATH", dir1+":"+dir2)
+	defer os.Unsetenv("FALBA_PARSERS_PATH")
+
+	// Create dummy result to avoid empty db
+	resultDir := filepath.Join(dbRoot, "test_result:123")
+	artifactsDir := filepath.Join(resultDir, "artifacts")
+	if err := os.MkdirAll(artifactsDir, 0755); err != nil {
+		t.Fatalf("Failed to create artifacts dir: %v", err)
+	}
+
+	dbInstance, err := db.ReadDB(dbRoot)
+	if err != nil {
+		t.Fatalf("Expected ReadDB to succeed, got error: %v", err)
+	}
+
+	if len(dbInstance.FactTypes) != 2 {
+		t.Errorf("Expected 2 fact types from loaded parsers, got %d", len(dbInstance.FactTypes))
+	}
+	if _, ok := dbInstance.FactTypes["fact1"]; !ok {
+		t.Errorf("Expected fact1 type to be loaded")
+	}
+	if _, ok := dbInstance.FactTypes["fact2"]; !ok {
+		t.Errorf("Expected fact2 type to be loaded")
+	}
+}
+
+// This test was written by Google Jules.
+func TestReadDB_FALBAParsersPath_Duplicate(t *testing.T) {
+	tempDir := t.TempDir()
+
+	dir1 := filepath.Join(tempDir, "parsers1")
+	dbRoot := filepath.Join(tempDir, "db_root")
+
+	if err := os.MkdirAll(dir1, 0755); err != nil {
+		t.Fatalf("Failed to create parsers1 dir: %v", err)
+	}
+	if err := os.MkdirAll(dbRoot, 0755); err != nil {
+		t.Fatalf("Failed to create db root dir: %v", err)
+	}
+
+	parser1Content := `{
+		"parsers": {
+			"parser_1": {
+				"type": "single_metric",
+				"artifact_regexp": "file1\\.txt",
+				"fact": {"name": "fact1", "type": "string"}
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(dir1, "config1.json"), []byte(parser1Content), 0644); err != nil {
+		t.Fatalf("Failed to write config1.json: %v", err)
+	}
+
+	dbParserContent := `{
+		"parsers": {
+			"parser_1": {
+				"type": "single_metric",
+				"artifact_regexp": "file2\\.txt",
+				"fact": {"name": "fact2", "type": "string"}
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(dbRoot, "parsers.json"), []byte(dbParserContent), 0644); err != nil {
+		t.Fatalf("Failed to write db root parsers.json: %v", err)
+	}
+
+	os.Setenv("FALBA_PARSERS_PATH", dir1)
+	defer os.Unsetenv("FALBA_PARSERS_PATH")
+
+	_, err := db.ReadDB(dbRoot)
+	if err == nil {
+		t.Fatalf("Expected ReadDB to fail due to duplicate parser name, but got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate parser name \"parser_1\"") {
+		t.Errorf("Expected duplicate parser error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Adds support for `FALBA_PARSERS_PATH` environment variable.

Instead of hard-coding the location of `parsers.json` in the db, `FALBA_PARSERS_PATH` provides a colon-separated list of directories that parsers are parsed from. All the `.json` parser config files in all the directories are merged into a single config. `parsers.json` in the db root is also parsed. An error is raised if duplicate parser names are detected.

Documentation and tests have been updated accordingly.

---
*PR created automatically by Jules for task [8864959018877818511](https://jules.google.com/task/8864959018877818511) started by @bjackman*